### PR TITLE
fix bugs with calculate_signature_point

### DIFF
--- a/lib/secp256k1/schnorr.ex
+++ b/lib/secp256k1/schnorr.ex
@@ -296,6 +296,9 @@ defmodule Bitcoinex.Secp256k1.Schnorr do
 
   # @spec calculate_signature_point(Point.t(), Point.(), <<_::256>>) :: Point.t() | {:error, String.t()}
   def calculate_signature_point(r_point, pk, z_bytes) do
+    {r_point, _} = make_point_even(r_point)
+    z_bytes = Utils.pad(z_bytes, 32, :leading)
+
     e =
       calculate_e(Point.x_bytes(r_point), Point.x_bytes(pk), z_bytes)
       |> PrivateKey.new()

--- a/test/secp256k1/schnorr_test.exs
+++ b/test/secp256k1/schnorr_test.exs
@@ -338,4 +338,17 @@ defmodule Bitcoinex.Secp256k1.SchnorrTest do
       end
     end
   end
+
+  describe "signature_point testing" do
+    test "signature_point matches sign_with_nonce" do
+      for _ <- 0..1000 do
+        {sk, pk, nonce, nonce_point, z, _aux} = get_rand_values_for_encrypted_sig()
+        sig_pk = Schnorr.calculate_signature_point(nonce_point, pk, :binary.encode_unsigned(z))
+        %Signature{s: s} = Schnorr.sign_with_nonce(sk, nonce, z)
+        {:ok, sig_sk} = PrivateKey.new(s)
+        # ensure that Signature.s is the privkey to the sig_point
+        assert PrivateKey.to_point(sig_sk) == sig_pk
+      end
+    end
+  end
 end


### PR DESCRIPTION
There were 2 bugs with this function `Schnorr.calculate_signature_point`:

We were not forcing the R-value (nonce_point) even
We were not padding the message hash to 32 bytes.