### PR TITLE
S0: Port BIP-340/341 negation foundation

### DIFF
--- a/lib/secp256k1/point.ex
+++ b/lib/secp256k1/point.ex
@@ -59,6 +59,9 @@ defmodule Bitcoinex.Secp256k1.Point do
           {:ok, y} -> {:ok, %__MODULE__{x: x, y: y}}
           _ -> {:error, "invalid public key"}
         end
+
+      _ ->
+        {:error, "invalid public key prefix"}
     end
   end
 
@@ -106,11 +109,14 @@ defmodule Bitcoinex.Secp256k1.Point do
   end
 
   @doc """
-    negate returns the pubkey with the same x but the other y (i.e. -P).
-    It flips the parity of y by passing `y % 2 == 0` as is_y_odd to Secp256k1.get_y.
+    negate returns -P: the point with the same x but the opposite-parity y.
+    The point at infinity negates to itself.
   """
   @spec negate(t()) :: t()
+  def negate(%__MODULE__{x: 0, y: 0} = infinity), do: infinity
+
   def negate(%__MODULE__{x: x, y: y}) do
+    # Flip parity: if y is even request the odd root, and vice versa.
     {:ok, y} = Secp256k1.get_y(x, (y &&& 1) == 0)
     %__MODULE__{x: x, y: y}
   end

--- a/lib/secp256k1/point.ex
+++ b/lib/secp256k1/point.ex
@@ -106,6 +106,16 @@ defmodule Bitcoinex.Secp256k1.Point do
   end
 
   @doc """
+    negate returns the pubkey with the same x but the other y (i.e. -P).
+    It flips the parity of y by passing `y % 2 == 0` as is_y_odd to Secp256k1.get_y.
+  """
+  @spec negate(t()) :: t()
+  def negate(%__MODULE__{x: x, y: y}) do
+    {:ok, y} = Secp256k1.get_y(x, (y &&& 1) == 0)
+    %__MODULE__{x: x, y: y}
+  end
+
+  @doc """
   sec serializes a compressed public key to binary
   """
   @spec sec(t()) :: binary

--- a/lib/secp256k1/privatekey.ex
+++ b/lib/secp256k1/privatekey.ex
@@ -61,13 +61,13 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
   end
 
   @doc """
-    negate returns the additive inverse of the private key (n - d). Its public
-    key is the negation of the original's. Used for BIP-340 even-Y normalization
-    and BIP-352 scalar arithmetic.
+    negate returns the additive inverse of the private key, `(n - d) mod n`. Its
+    public key is the negation of the original's. Used for BIP-340 even-Y
+    normalization and BIP-352 scalar arithmetic.
   """
   @spec negate(t()) :: t()
   def negate(%__MODULE__{d: d}) do
-    %__MODULE__{d: @n - d}
+    %__MODULE__{d: Math.modulo(@n - d, @n)}
   end
 
   @doc """
@@ -79,11 +79,8 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
       {:error, msg} ->
         {:error, msg}
 
-      {:ok, %__MODULE__{d: d}} ->
-        d
-        |> :binary.encode_unsigned()
-        |> Utils.pad(32, :leading)
-        |> Base.encode16(case: :lower)
+      {:ok, sk} ->
+        to_hex(sk)
     end
   end
 

--- a/lib/secp256k1/privatekey.ex
+++ b/lib/secp256k1/privatekey.ex
@@ -61,6 +61,16 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
   end
 
   @doc """
+    negate returns the additive inverse of the private key (n - d). Its public
+    key is the negation of the original's. Used for BIP-340 even-Y normalization
+    and BIP-352 scalar arithmetic.
+  """
+  @spec negate(t()) :: t()
+  def negate(%__MODULE__{d: d}) do
+    %__MODULE__{d: @n - d}
+  end
+
+  @doc """
    serialize_private_key serializes a private key into hex
   """
   @spec serialize_private_key(t()) :: String.t()
@@ -75,6 +85,18 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
         |> Utils.pad(32, :leading)
         |> Base.encode16(case: :lower)
     end
+  end
+
+  @doc """
+    to_hex serializes a private key to a 32-byte (64-char) lowercase hex string.
+    Unlike serialize_private_key/1 it does not validate the key range.
+  """
+  @spec to_hex(t()) :: String.t()
+  def to_hex(%__MODULE__{d: d}) do
+    d
+    |> :binary.encode_unsigned()
+    |> Utils.pad(32, :leading)
+    |> Base.encode16(case: :lower)
   end
 
   @doc """

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -215,7 +215,7 @@ defmodule Bitcoinex.Secp256k1 do
           if Point.has_even_y(pubkey) do
             privkey
           else
-            %PrivateKey{d: Params.curve().n - privkey.d}
+            PrivateKey.negate(privkey)
           end
         end
     end

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -113,7 +113,17 @@ defmodule Bitcoinex.Secp256k1 do
 
     @spec serialize_signature(t()) :: binary
     def serialize_signature(%__MODULE__{r: r, s: s}) do
-      :binary.encode_unsigned(r) <> :binary.encode_unsigned(s)
+      Utils.int_to_big(r, 32) <> Utils.int_to_big(s, 32)
+    end
+
+    @doc """
+    to_hex returns the compact 64-byte (r || s) signature as a lowercase hex string.
+    """
+    @spec to_hex(t()) :: String.t()
+    def to_hex(sig = %__MODULE__{}) do
+      sig
+      |> serialize_signature()
+      |> Base.encode16(case: :lower)
     end
 
     @doc """

--- a/test/secp256k1/point_test.exs
+++ b/test/secp256k1/point_test.exs
@@ -71,6 +71,13 @@ defmodule Bitcoinex.Secp256k1.PointTest do
       assert Point.parse_public_key(sec) == {:ok, pk}
       assert Point.serialize_public_key(pk) == sec
     end
+
+    test "returns error (does not raise) for a 33-byte key with an invalid prefix byte" do
+      for prefix <- [0x00, 0x01, 0x04, 0x05, 0x06, 0xFF] do
+        bad = <<prefix>> <> :binary.copy(<<0x07>>, 32)
+        assert {:error, _} = Point.parse_public_key(bad)
+      end
+    end
   end
 
   describe "sec/1" do
@@ -135,6 +142,11 @@ defmodule Bitcoinex.Secp256k1.PointTest do
       even = "023b15e1b8c51bb947a134d17addc3eb6abbda551ad02137699636f907ad7e0f1a"
       {:ok, point} = Point.parse_public_key(Base.decode16!(odd, case: :lower))
       assert Point.sec(Point.negate(point)) == Base.decode16!(even, case: :lower)
+    end
+
+    test "the point at infinity negates to itself" do
+      infinity = %Point{x: 0, y: 0}
+      assert Point.negate(infinity) == infinity
     end
   end
 end

--- a/test/secp256k1/point_test.exs
+++ b/test/secp256k1/point_test.exs
@@ -108,4 +108,33 @@ defmodule Bitcoinex.Secp256k1.PointTest do
       end
     end
   end
+
+  describe "negate/1" do
+    test "preserves x, flips y-parity, and is the additive inverse" do
+      p = Secp256k1.Params.curve().p
+
+      for hex <- @x_only_pubkeys do
+        {:ok, point} = Point.lift_x(hex)
+        neg = Point.negate(point)
+
+        assert neg.x == point.x
+        assert neg.y == p - point.y
+        # lift_x returns the even-Y point; its negation is odd-Y
+        assert Point.has_even_y(point)
+        refute Point.has_even_y(neg)
+        # P + (-P) is the point at infinity
+        assert Point.is_inf(Secp256k1.Math.add(point, neg))
+        # negation is an involution
+        assert Point.negate(neg).x == point.x
+        assert Point.negate(neg).y == point.y
+      end
+    end
+
+    test "negation switches the SEC parity byte (03 <-> 02), x unchanged" do
+      odd = "033b15e1b8c51bb947a134d17addc3eb6abbda551ad02137699636f907ad7e0f1a"
+      even = "023b15e1b8c51bb947a134d17addc3eb6abbda551ad02137699636f907ad7e0f1a"
+      {:ok, point} = Point.parse_public_key(Base.decode16!(odd, case: :lower))
+      assert Point.sec(Point.negate(point)) == Base.decode16!(even, case: :lower)
+    end
+  end
 end

--- a/test/secp256k1/privatekey_test.exs
+++ b/test/secp256k1/privatekey_test.exs
@@ -2,7 +2,7 @@ defmodule Bitcoinex.Secp256k1.PrivateKeyTest do
   use ExUnit.Case
   doctest Bitcoinex.Secp256k1.PrivateKey
 
-  alias Bitcoinex.Secp256k1.PrivateKey
+  alias Bitcoinex.Secp256k1.{Params, Point, PrivateKey}
 
   describe "serialize_private_key/1" do
     test "successfully pad private key" do
@@ -40,6 +40,39 @@ defmodule Bitcoinex.Secp256k1.PrivateKeyTest do
       sk = %PrivateKey{d: 123_414_253_234_542_345_423_623}
       wif = PrivateKey.wif!(sk, :mainnet)
       assert {:ok, sk, :mainnet, true} == PrivateKey.parse_wif(wif)
+    end
+  end
+
+  describe "negate/1" do
+    test "returns n - d and is an involution" do
+      n = Params.curve().n
+      sk = %PrivateKey{d: 123_414_253_234_542_345_423_623}
+      neg = PrivateKey.negate(sk)
+
+      assert neg.d == n - sk.d
+      assert PrivateKey.negate(neg) == sk
+      assert rem(sk.d + neg.d, n) == 0
+    end
+
+    test "public key of the negated key is the negated public key" do
+      sk = %PrivateKey{d: 123_414_253_234_542_345_423_623}
+
+      assert PrivateKey.to_point(PrivateKey.negate(sk)) ==
+               Point.negate(PrivateKey.to_point(sk))
+    end
+  end
+
+  describe "to_hex/1" do
+    test "serializes to 64-char hex with leading-zero padding" do
+      assert PrivateKey.to_hex(%PrivateKey{d: 1}) ==
+               "0000000000000000000000000000000000000000000000000000000000000001"
+
+      sk = %PrivateKey{d: 123_414_253_234_542_345_423_623}
+
+      assert PrivateKey.to_hex(sk) ==
+               "000000000000000000000000000000000000000000001a224cd1a01427f38b07"
+
+      assert String.length(PrivateKey.to_hex(sk)) == 64
     end
   end
 end

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -176,21 +176,28 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
       assert String.length(Signature.to_hex(sig)) == 128
     end
 
-    test "to_hex round-trips through parse_signature" do
-      sig = %Signature{
-        r:
-          3_086_008_707_114_705_845_761_137_809_128_827_774_006_369_836_063_216_572_143_683_251_326_398_205_321,
-        s:
-          48_832_473_706_270_939_780_454_642_696_934_734_127_348_929_209_136_601_810_472_271_862_324_755_985_375
-      }
+    test "to_hex round-trips through parse_signature (incl. small/leading-zero r,s)" do
+      sigs = [
+        %Signature{
+          r:
+            3_086_008_707_114_705_845_761_137_809_128_827_774_006_369_836_063_216_572_143_683_251_326_398_205_321,
+          s:
+            48_832_473_706_270_939_780_454_642_696_934_734_127_348_929_209_136_601_810_472_271_862_324_755_985_375
+        },
+        # r and s with leading zero bytes — would round-trip incorrectly under the old
+        # variable-length serialization, exercising the 32-byte padding fix.
+        %Signature{r: 1, s: 1}
+      ]
 
-      {:ok, parsed} =
-        sig
-        |> Signature.to_hex()
-        |> Base.decode16!(case: :lower)
-        |> Signature.parse_signature()
+      for sig <- sigs do
+        {:ok, parsed} =
+          sig
+          |> Signature.to_hex()
+          |> Base.decode16!(case: :lower)
+          |> Signature.parse_signature()
 
-      assert parsed == sig
+        assert parsed == sig
+      end
     end
   end
 end

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -165,4 +165,32 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
       end
     end
   end
+
+  describe "Signature.serialize_signature/1 and to_hex/1" do
+    test "pads r and s each to 32 bytes (64-byte compact signature)" do
+      sig = %Signature{r: 1, s: 1}
+      assert byte_size(Signature.serialize_signature(sig)) == 64
+
+      expected = String.duplicate("0", 63) <> "1" <> String.duplicate("0", 63) <> "1"
+      assert Signature.to_hex(sig) == expected
+      assert String.length(Signature.to_hex(sig)) == 128
+    end
+
+    test "to_hex round-trips through parse_signature" do
+      sig = %Signature{
+        r:
+          3_086_008_707_114_705_845_761_137_809_128_827_774_006_369_836_063_216_572_143_683_251_326_398_205_321,
+        s:
+          48_832_473_706_270_939_780_454_642_696_934_734_127_348_929_209_136_601_810_472_271_862_324_755_985_375
+      }
+
+      {:ok, parsed} =
+        sig
+        |> Signature.to_hex()
+        |> Base.decode16!(case: :lower)
+        |> Signature.parse_signature()
+
+      assert parsed == sig
+    end
+  end
 end


### PR DESCRIPTION
## Summary

First PR in the BIP-352 Silent Payments stack (see `docs/specs/bip352-silent-payments.md`). Ports the small secp256k1 negation/serialization helpers SP builds on, from `SachinMeier/bitcoinex@master`.

- `Point.negate/1` — same `x`, opposite-parity `y` (i.e. `-P`); needed by SP label matching (`output − P_k`).
- `PrivateKey.negate/1` — `n - d`.
- `PrivateKey.to_hex/1`, `Signature.to_hex/1` — hex serialization helpers (test ergonomics).
- `Signature.serialize_signature/1` now left-pads `r` and `s` to 32 bytes each, so a compact signature is always the correct 64 bytes (BIP-340). Existing schnorr vectors have no leading-zero `r`/`s`, so their serialization is unchanged.

## Test plan

- New unit tests: `Point.negate/1` (x preserved, parity flipped, `P + (-P) = ∞`, involution, priv/pub correspondence), `PrivateKey.negate/1`, `PrivateKey.to_hex/1`, `Signature.serialize_signature/1` + `to_hex/1` padding & round-trip.
- `mix test` (185 tests, 0 failures) and `mix lint.all` pass locally on Elixir 1.18.1 / OTP 27.

## Stack
- **S0 (this PR)** → S1 primitives → S2 send/scan/spend + labels → S3 address codec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)