### PR TITLE
S1: BIP-352 Silent Payments crypto primitives

### DIFF
--- a/lib/silent_payments.ex
+++ b/lib/silent_payments.ex
@@ -1,0 +1,242 @@
+defmodule Bitcoinex.SilentPayments do
+  @moduledoc """
+  Cryptographic primitives for BIP-352 Silent Payments.
+
+  https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki
+
+  This module implements the key-derivation math a Silent Payments wallet or
+  scanner builds on. It is intentionally **lean**: it does not select coins,
+  parse transactions, extract input public keys from scriptSigs/witnesses,
+  choose the lexicographically smallest outpoint, or drive the scan loop. The
+  caller owns the transaction and supplies the already-summed keys, the chosen
+  `outpoint_L`, and the output index `k`.
+
+  All public functions return `{:ok, value}` or `{:error, reason}`.
+
+  ## Notation
+
+  Uppercase = public keys (`Point`), lowercase = private keys (`PrivateKey`),
+  `·` = EC scalar multiplication, `G` = generator, `n` = curve order.
+
+  The protocol uses three BIP-340 tagged hashes:
+
+    * `BIP0352/Inputs`       — `input_hash/2`
+    * `BIP0352/SharedSecret` — `shared_secret_tweak/2` (`t_k`)
+    * `BIP0352/Label`        — `label_tweak/2`
+
+  ## Pipeline
+
+      # sender computes the per-output taproot key (see Bitcoinex.SilentPayments later PRs)
+      {:ok, ih} = input_hash(outpoint_l, a_pub_sum)
+      {:ok, ecdh} = shared_secret(a_priv_sum, b_scan, ih)
+      {:ok, t_k} = shared_secret_tweak(ecdh, 0)
+      # P_0 = B_spend + t_k·G
+  """
+
+  alias Bitcoinex.Utils
+  alias Bitcoinex.Secp256k1
+  alias Bitcoinex.Secp256k1.{Math, Params, Point, PrivateKey}
+
+  @n Params.curve().n
+
+  @input_tag "BIP0352/Inputs"
+  @shared_secret_tag "BIP0352/SharedSecret"
+  @label_tag "BIP0352/Label"
+
+  @typedoc "A 36-byte outpoint: 32-byte txid (little-endian) followed by a 4-byte vout (little-endian)."
+  @type outpoint :: <<_::288>>
+
+  @doc """
+  input_hash computes `hash_BIP0352/Inputs(outpoint_L || ser_P(A))` as a 32-byte scalar.
+
+  `outpoint_L` is the lexicographically smallest 36-byte outpoint among the
+  transaction's inputs (the caller selects it, e.g. with `Enum.min/1`). `A` is
+  the sum of the input public keys.
+
+  Fails if the resulting value is not a valid scalar (`0` or `>= n`).
+  """
+  @spec input_hash(outpoint(), Point.t()) :: {:ok, <<_::256>>} | {:error, String.t()}
+  def input_hash(<<outpoint::binary-size(36)>>, %Point{} = a_sum_pubkey) do
+    hash = Utils.tagged_hash(@input_tag, outpoint <> Point.sec(a_sum_pubkey))
+
+    if valid_scalar?(hash) do
+      {:ok, hash}
+    else
+      {:error, "input_hash is not a valid scalar"}
+    end
+  end
+
+  def input_hash(_, _), do: {:error, "outpoint must be 36 bytes"}
+
+  @doc """
+  shared_secret computes the ECDH point `input_hash · scalar · point`.
+
+    * sender passes `(a_sum_privkey, B_scan, input_hash)`
+    * receiver passes `(b_scan_privkey, A, input_hash)`
+
+  Both parties arrive at the same point. Fails if the result is the point at
+  infinity (or the effective scalar reduces to zero).
+  """
+  @spec shared_secret(PrivateKey.t(), Point.t(), <<_::256>>) ::
+          {:ok, Point.t()} | {:error, String.t()}
+  def shared_secret(%PrivateKey{d: d}, %Point{} = point, <<input_hash::binary-size(32)>>) do
+    scalar = Math.modulo(d * :binary.decode_unsigned(input_hash), @n)
+
+    if scalar == 0 do
+      {:error, "shared secret scalar is zero"}
+    else
+      secret = Math.multiply(point, scalar)
+
+      if Point.is_inf(secret) do
+        {:error, "shared secret is the point at infinity"}
+      else
+        {:ok, secret}
+      end
+    end
+  end
+
+  @doc """
+  shared_secret_tweak computes the per-output tweak
+  `t_k = hash_BIP0352/SharedSecret(ser_P(ecdh_secret) || ser_32(k))`.
+
+  Fails if `t_k` is not a valid scalar (`0` or `>= n`).
+  """
+  @spec shared_secret_tweak(Point.t(), non_neg_integer()) ::
+          {:ok, PrivateKey.t()} | {:error, String.t()}
+  def shared_secret_tweak(%Point{} = ecdh_secret, k) when is_integer(k) and k >= 0 do
+    tweak =
+      Utils.tagged_hash(@shared_secret_tag, Point.sec(ecdh_secret) <> Utils.int_to_big(k, 4))
+
+    if valid_scalar?(tweak) do
+      PrivateKey.new(:binary.decode_unsigned(tweak))
+    else
+      {:error, "shared secret tweak t_k is not a valid scalar"}
+    end
+  end
+
+  @doc """
+  sum_input_privkeys sums the input private keys into the aggregate spend key `a`.
+
+  Taproot keys (first argument) are negated to their even-Y form before summing,
+  per BIP-352; all other eligible keys (second argument) are summed as-is. The
+  sum is taken mod `n`, so an intermediate sum of zero is fine — only the final
+  sum being zero is an error (and means no outputs can be produced).
+  """
+  @spec sum_input_privkeys([PrivateKey.t()], [PrivateKey.t()]) ::
+          {:ok, PrivateKey.t()} | {:error, String.t()}
+  def sum_input_privkeys(taproot, other) when is_list(taproot) and is_list(other) do
+    with {:ok, taproot_even} <- force_even_all(taproot) do
+      case taproot_even ++ other do
+        [] ->
+          {:error, "no input private keys"}
+
+        keys ->
+          sum =
+            keys |> Enum.reduce(0, fn %PrivateKey{d: d}, acc -> acc + d end) |> Math.modulo(@n)
+
+          if sum == 0 do
+            {:error, "input private key sum is zero"}
+          else
+            PrivateKey.new(sum)
+          end
+      end
+    end
+  end
+
+  @doc """
+  sum_input_pubkeys sums the input public keys into the aggregate `A`.
+
+  Taproot inputs are supplied as 32-byte x-only keys (first argument) and lifted
+  to their even-Y point; all other eligible inputs are supplied as `Point`s
+  (second argument). Addition is commutative, so input order does not matter. An
+  intermediate point at infinity is fine — only the final sum being the point at
+  infinity is an error (and means the transaction is skipped).
+  """
+  @spec sum_input_pubkeys([<<_::256>>], [Point.t()]) :: {:ok, Point.t()} | {:error, String.t()}
+  def sum_input_pubkeys(taproot_xonly, other) when is_list(taproot_xonly) and is_list(other) do
+    with {:ok, taproot_points} <- lift_all(taproot_xonly) do
+      case taproot_points ++ other do
+        [] ->
+          {:error, "no input public keys"}
+
+        [first | rest] ->
+          sum = Enum.reduce(rest, first, fn p, acc -> Math.add(acc, p) end)
+
+          if Point.is_inf(sum) do
+            {:error, "input public key sum is the point at infinity"}
+          else
+            {:ok, sum}
+          end
+      end
+    end
+  end
+
+  @doc """
+  label_tweak computes the label scalar
+  `hash_BIP0352/Label(ser_256(b_scan) || ser_32(m))`.
+
+  `b_scan` is the receiver's scan **private** key. `m` is the label integer
+  (`m = 0` is reserved for the change label). Fails if the tweak is not a valid
+  scalar.
+  """
+  @spec label_tweak(PrivateKey.t(), non_neg_integer()) ::
+          {:ok, PrivateKey.t()} | {:error, String.t()}
+  def label_tweak(%PrivateKey{d: b_scan}, m) when is_integer(m) and m >= 0 do
+    tweak = Utils.tagged_hash(@label_tag, Utils.int_to_big(b_scan, 32) <> Utils.int_to_big(m, 4))
+
+    if valid_scalar?(tweak) do
+      PrivateKey.new(:binary.decode_unsigned(tweak))
+    else
+      {:error, "label tweak is not a valid scalar"}
+    end
+  end
+
+  @doc """
+  label_point computes the label point `label_tweak(m)·G`.
+
+  This is what a scanner precomputes and stores (keyed by `m`) to recognize
+  labeled outputs. Always include `m = 0` (the change label) when scanning.
+  """
+  @spec label_point(PrivateKey.t(), non_neg_integer()) :: {:ok, Point.t()} | {:error, String.t()}
+  def label_point(%PrivateKey{} = b_scan, m) do
+    with {:ok, tweak} <- label_tweak(b_scan, m) do
+      {:ok, PrivateKey.to_point(tweak)}
+    end
+  end
+
+  # A 32-byte hash is a valid secp256k1 scalar when it is neither 0 nor >= n.
+  defp valid_scalar?(<<bytes::binary-size(32)>>) do
+    i = :binary.decode_unsigned(bytes)
+    i != 0 and i < @n
+  end
+
+  # Negate each taproot private key to its even-Y form. Short-circuits on error.
+  defp force_even_all(keys) do
+    keys
+    |> Enum.reduce_while({:ok, []}, fn key, {:ok, acc} ->
+      case Secp256k1.force_even_y(key) do
+        %PrivateKey{} = k -> {:cont, {:ok, [k | acc]}}
+        {:error, msg} -> {:halt, {:error, msg}}
+      end
+    end)
+    |> case do
+      {:ok, ks} -> {:ok, Enum.reverse(ks)}
+      err -> err
+    end
+  end
+
+  # Lift each 32-byte x-only key to its even-Y point. Short-circuits on error.
+  defp lift_all(xonly_keys) do
+    xonly_keys
+    |> Enum.reduce_while({:ok, []}, fn xonly, {:ok, acc} ->
+      case Point.lift_x(xonly) do
+        {:ok, point} -> {:cont, {:ok, [point | acc]}}
+        {:error, msg} -> {:halt, {:error, msg}}
+      end
+    end)
+    |> case do
+      {:ok, points} -> {:ok, Enum.reverse(points)}
+      err -> err
+    end
+  end
+end

--- a/lib/silent_payments.ex
+++ b/lib/silent_payments.ex
@@ -74,8 +74,9 @@ defmodule Bitcoinex.SilentPayments do
     * sender passes `(a_sum_privkey, B_scan, input_hash)`
     * receiver passes `(b_scan_privkey, A, input_hash)`
 
-  Both parties arrive at the same point. Fails if the result is the point at
-  infinity (or the effective scalar reduces to zero).
+  `input_hash` must be a pre-validated 32-byte scalar (as produced by
+  `input_hash/2`). Both parties arrive at the same point. Fails if the result is
+  the point at infinity (or the effective scalar reduces to zero).
   """
   @spec shared_secret(PrivateKey.t(), Point.t(), <<_::256>>) ::
           {:ok, Point.t()} | {:error, String.t()}
@@ -205,6 +206,8 @@ defmodule Bitcoinex.SilentPayments do
   end
 
   # A 32-byte hash is a valid secp256k1 scalar when it is neither 0 nor >= n.
+  # Note: PrivateKey.new/1 only rejects d >= n, so this guard is what enforces
+  # the non-zero requirement before the callers build a PrivateKey from the hash.
   defp valid_scalar?(<<bytes::binary-size(32)>>) do
     i = :binary.decode_unsigned(bytes)
     i != 0 and i < @n

--- a/test/silent_payments_test.exs
+++ b/test/silent_payments_test.exs
@@ -1,0 +1,194 @@
+defmodule Bitcoinex.SilentPaymentsTest do
+  use ExUnit.Case, async: true
+  doctest Bitcoinex.SilentPayments
+
+  alias Bitcoinex.SilentPayments
+  alias Bitcoinex.Secp256k1
+  alias Bitcoinex.Secp256k1.{Point, PrivateKey}
+
+  # Values taken from the BIP-352 "Simple send: two inputs" test vector.
+  @sk1 "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1"
+  @sk2 "93f5ed907ad5b2bdbbdcb5d9116ebc0a4e1f92f910d5260237fa45a9408aad16"
+  @priv_sum "7ed265a6dac7aba8508a32d6d6b84c7f1dbd0a0941dd01088d69e8d556345f86"
+  @pub1 "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5"
+  @pub2 "03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792"
+  @scan_pub "0220bcfac5b99e04ad1a06ddfb016ee13582609d60b6291e98d01a9bc9a16c96d4"
+  @scan_priv "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c"
+  @txid1 "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16"
+  @txid2 "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"
+  @shared_secret "028158aff7d61ea66b2fa7f555bc3c5937d1debbde16423d630f9aa7943e14d80d"
+  @tweak_0 "f438b40179a3c4262de12986c0e6cce0634007cdc79c1dcd3e20b9ebc2e7eef6"
+
+  defp privkey(hex),
+    do: %PrivateKey{d: hex |> Base.decode16!(case: :lower) |> :binary.decode_unsigned()}
+
+  defp point(hex) do
+    {:ok, p} = Point.parse_public_key(Base.decode16!(hex, case: :lower))
+    p
+  end
+
+  defp xonly(compressed_hex),
+    do: Base.decode16!(String.slice(compressed_hex, 2, 64), case: :lower)
+
+  # outpoint = txid (little-endian / reversed) || vout (4-byte little-endian)
+  defp outpoint(txid_hex, vout) do
+    txid_le =
+      txid_hex
+      |> Base.decode16!(case: :lower)
+      |> :binary.bin_to_list()
+      |> Enum.reverse()
+      |> :binary.list_to_bin()
+
+    txid_le <> <<vout::little-size(32)>>
+  end
+
+  describe "sum_input_privkeys/2" do
+    test "sums non-taproot keys (matches the vector's input_private_key_sum)" do
+      assert SilentPayments.sum_input_privkeys([], [privkey(@sk1), privkey(@sk2)]) ==
+               {:ok, privkey(@priv_sum)}
+    end
+
+    test "negates a taproot key whose pubkey is odd-Y" do
+      k = privkey(@sk2)
+      refute Point.has_even_y(PrivateKey.to_point(k))
+
+      assert SilentPayments.sum_input_privkeys([k], []) == {:ok, PrivateKey.negate(k)}
+
+      {:ok, summed} = SilentPayments.sum_input_privkeys([k], [])
+      assert Point.has_even_y(PrivateKey.to_point(summed))
+    end
+
+    test "leaves an already-even-Y taproot key unchanged" do
+      k = privkey(@sk1)
+      assert Point.has_even_y(PrivateKey.to_point(k))
+      assert SilentPayments.sum_input_privkeys([k], []) == {:ok, k}
+    end
+
+    test "does not negate non-taproot keys" do
+      k = privkey(@sk2)
+      assert SilentPayments.sum_input_privkeys([], [k]) == {:ok, k}
+    end
+
+    test "errors when the final sum is zero" do
+      k = privkey(@sk1)
+      assert {:error, _} = SilentPayments.sum_input_privkeys([], [k, PrivateKey.negate(k)])
+    end
+
+    test "allows an intermediate zero sum when the final sum is non-zero" do
+      k = privkey(@sk1)
+      assert SilentPayments.sum_input_privkeys([], [k, PrivateKey.negate(k), k]) == {:ok, k}
+    end
+
+    test "errors with no inputs" do
+      assert {:error, _} = SilentPayments.sum_input_privkeys([], [])
+    end
+  end
+
+  describe "sum_input_pubkeys/2" do
+    test "sums compressed pubkeys and equals the privkey-sum's point" do
+      assert SilentPayments.sum_input_pubkeys([], [point(@pub1), point(@pub2)]) ==
+               {:ok, PrivateKey.to_point(privkey(@priv_sum))}
+    end
+
+    test "lifts taproot x-only inputs to their even-Y point" do
+      {:ok, lifted} = Point.lift_x(xonly(@pub1))
+      assert SilentPayments.sum_input_pubkeys([xonly(@pub1)], []) == {:ok, lifted}
+    end
+
+    test "errors when the sum is the point at infinity" do
+      p = point(@pub1)
+      assert {:error, _} = SilentPayments.sum_input_pubkeys([], [p, Point.negate(p)])
+    end
+
+    test "allows an intermediate point at infinity when the final sum is finite" do
+      p = point(@pub1)
+      {:ok, sum} = SilentPayments.sum_input_pubkeys([], [p, Point.negate(p), p])
+      assert sum.x == p.x and sum.y == p.y
+    end
+
+    test "errors with no inputs" do
+      assert {:error, _} = SilentPayments.sum_input_pubkeys([], [])
+    end
+  end
+
+  describe "input_hash/2" do
+    test "rejects an outpoint that is not 36 bytes" do
+      assert {:error, _} = SilentPayments.input_hash(<<0::size(280)>>, point(@pub1))
+      assert {:error, _} = SilentPayments.input_hash(<<0::size(296)>>, point(@pub1))
+    end
+
+    test "is deterministic and returns 32 bytes" do
+      op = outpoint(@txid1, 0)
+      {:ok, h1} = SilentPayments.input_hash(op, point(@pub1))
+      {:ok, h2} = SilentPayments.input_hash(op, point(@pub1))
+      assert h1 == h2
+      assert byte_size(h1) == 32
+    end
+  end
+
+  describe "input_hash/2 -> shared_secret/3 -> shared_secret_tweak/2 (BIP-352 vector chain)" do
+    test "derives the vector's shared_secret and t_0" do
+      {:ok, a_sum} = SilentPayments.sum_input_privkeys([], [privkey(@sk1), privkey(@sk2)])
+      a_pub = PrivateKey.to_point(a_sum)
+
+      outpoint_l = Enum.min([outpoint(@txid1, 0), outpoint(@txid2, 0)])
+      {:ok, input_hash} = SilentPayments.input_hash(outpoint_l, a_pub)
+
+      {:ok, ecdh} = SilentPayments.shared_secret(a_sum, point(@scan_pub), input_hash)
+      assert Point.sec(ecdh) == Base.decode16!(@shared_secret, case: :lower)
+
+      {:ok, t0} = SilentPayments.shared_secret_tweak(ecdh, 0)
+      assert PrivateKey.to_hex(t0) == @tweak_0
+    end
+  end
+
+  describe "shared_secret/3" do
+    test "is symmetric between sender and receiver (ECDH)" do
+      a = %PrivateKey{d: 12_345}
+      b = %PrivateKey{d: 67_890}
+      input_hash = :binary.copy(<<0x42>>, 32)
+
+      {:ok, s1} = SilentPayments.shared_secret(a, PrivateKey.to_point(b), input_hash)
+      {:ok, s2} = SilentPayments.shared_secret(b, PrivateKey.to_point(a), input_hash)
+      assert s1 == s2
+    end
+  end
+
+  describe "shared_secret_tweak/2" do
+    test "depends on the output index k" do
+      ecdh = point(@shared_secret)
+      {:ok, t0} = SilentPayments.shared_secret_tweak(ecdh, 0)
+      {:ok, t1} = SilentPayments.shared_secret_tweak(ecdh, 1)
+      refute t0 == t1
+    end
+  end
+
+  describe "label_tweak/2 and label_point/2" do
+    test "label_point is label_tweak * G" do
+      b_scan = privkey(@scan_priv)
+      {:ok, tweak} = SilentPayments.label_tweak(b_scan, 1)
+      {:ok, lp} = SilentPayments.label_point(b_scan, 1)
+      assert lp == PrivateKey.to_point(tweak)
+    end
+
+    test "different label integers give different tweaks (incl. m = 0 change label)" do
+      b_scan = privkey(@scan_priv)
+      {:ok, t0} = SilentPayments.label_tweak(b_scan, 0)
+      {:ok, t1} = SilentPayments.label_tweak(b_scan, 1)
+      {:ok, t2} = SilentPayments.label_tweak(b_scan, 2)
+      assert t0 != t1 and t1 != t2 and t0 != t2
+    end
+
+    test "is deterministic" do
+      b_scan = privkey(@scan_priv)
+      assert SilentPayments.label_tweak(b_scan, 5) == SilentPayments.label_tweak(b_scan, 5)
+    end
+  end
+
+  test "force_even_y agreement: a single taproot privkey sums to its even-Y form" do
+    for hex <- [@sk1, @sk2] do
+      k = privkey(hex)
+      assert SilentPayments.sum_input_privkeys([k], []) == {:ok, Secp256k1.force_even_y(k)}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Second PR in the BIP-352 Silent Payments stack. Adds `Bitcoinex.SilentPayments` with the core key-derivation math (no wallet/scanner concerns — see `docs/specs/bip352-silent-payments.md`).

- `input_hash/2` — `hash_BIP0352/Inputs(outpoint_L || ser_P(A))`, validates the scalar range.
- `shared_secret/3` — ECDH point `input_hash * scalar * point`; sender passes `(a, B_scan, ih)`, receiver `(b_scan, A, ih)`.
- `shared_secret_tweak/2` — `t_k = hash_BIP0352/SharedSecret(ser_P(ecdh) || ser_32(k))`.
- `sum_input_privkeys/2` — aggregate `a`; taproot keys negated to even-Y; errors only on a zero **final** sum.
- `sum_input_pubkeys/2` — aggregate `A`; taproot x-only lifted to even-Y; errors only on a final point at infinity.
- `label_tweak/2`, `label_point/2` — BIP-352 labels (`m = 0` is the change label).

## Test plan

- Concrete vector chain: `sum_input_privkeys -> input_hash -> shared_secret -> shared_secret_tweak` reproduces the "Simple send: two inputs" vector's `shared_secret` and `t_0`.
- ECDH symmetry (sender == receiver), even-Y negation (odd-Y key negated, even-Y unchanged), zero-sum / intermediate-zero / point-at-infinity handling, `label_point = label_tweak * G`, determinism, and error cases.
- `mix test` (206 tests, 0 failures) and `mix lint.all` pass on Elixir 1.18.1 / OTP 27.

## Stack

S0 negation -> **S1 (this PR)** -> S2 send/scan/spend + labels -> S3 address codec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
