### PR TITLE
S3: BIP-352 silent payment address codec (sp1q / tsp1q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2026-06-15
+### Added
+- BIP-352 Silent Payments primitives in `Bitcoinex.SilentPayments`: `input_hash/2`, `shared_secret/3`, `shared_secret_tweak/2`, `sum_input_privkeys/2`, `sum_input_pubkeys/2`, label tweaks (`label_tweak/2`, `label_point/2`, `create_labeled_spend_pubkey/3`), send/scan/spend derivation (`create_output_pubkey/5`, `scan_output/5`, `spending_privkey/3`, `output_label_candidates/2`), and `sp1q…`/`tsp1q…` address `encode_address/3` / `decode_address/1`. Validated against the official BIP-352 test vectors.
+- `Bitcoinex.Secp256k1.Point.negate/1`, `PrivateKey.negate/1`, `PrivateKey.to_hex/1`, and `Signature.to_hex/1`.
+
+### Changed
+- `Secp256k1.Signature.serialize_signature/1` now left-pads `r` and `s` so a compact signature is always the correct 64 bytes (BIP-340).
+
 ## [0.1.8] - 2024-03-01
 ### Added
 - Fix warning emitted from String.slice with negative step when parsing amountful BOLT11 invoices.

--- a/lib/silent_payments.ex
+++ b/lib/silent_payments.ex
@@ -440,6 +440,9 @@ defmodule Bitcoinex.SilentPayments do
   defp parse_sp_data([31 | _rest]), do: {:error, "silent payment version 31 is not supported"}
 
   defp parse_sp_data([version | rest]) when version in 0..30 do
+    # convert_bits(_, 5, 8, padding: false) requires the trailing bech32 bits to be valid
+    # zero-padding, so a malformed data part is rejected here. This matches the BIP-352
+    # reference (and Segwit) decoding; future SP versions still carry byte-aligned payloads.
     case Bech32.convert_bits(rest, 5, 8, false) do
       {:ok, bytes} ->
         payload = :erlang.list_to_binary(bytes)

--- a/lib/silent_payments.ex
+++ b/lib/silent_payments.ex
@@ -33,11 +33,12 @@ defmodule Bitcoinex.SilentPayments do
       # P_0 = B_spend + t_k·G
   """
 
-  alias Bitcoinex.Utils
+  alias Bitcoinex.{Bech32, Utils}
   alias Bitcoinex.Secp256k1
   alias Bitcoinex.Secp256k1.{Math, Params, Point, PrivateKey}
 
   @n Params.curve().n
+  @sp_version 0
 
   @input_tag "BIP0352/Inputs"
   @shared_secret_tag "BIP0352/SharedSecret"
@@ -327,6 +328,45 @@ defmodule Bitcoinex.SilentPayments do
 
   def output_label_candidates(%Point{}, _output), do: {:error, "output must be 32 bytes"}
 
+  @doc """
+  encode_address encodes a silent payment address.
+
+  It is the Bech32m encoding of silent-payment version 0 followed by
+  `ser_P(B_scan) || ser_P(B_m)` (66 bytes). The HRP is `sp` for `:mainnet` and `tsp` for
+  `:testnet`/`:regtest`. `b_m` is the (possibly labeled) spend public key — pass `B_spend`
+  for an unlabeled address or the output of `create_labeled_spend_pubkey/3` for a labeled one.
+  """
+  @spec encode_address(Point.t(), Point.t(), Bitcoinex.Network.network_name()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def encode_address(%Point{} = b_scan, %Point{} = b_m, network) do
+    with {:ok, hrp} <- hrp_for(network),
+         payload = :binary.bin_to_list(Point.sec(b_scan) <> Point.sec(b_m)),
+         {:ok, data} <- Bech32.convert_bits(payload, 8, 5),
+         {:ok, address} <- Bech32.encode(hrp, [@sp_version | data], :bech32m, :infinity) do
+      {:ok, address}
+    else
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
+  @doc """
+  decode_address decodes a silent payment address into `{network, version, B_scan, B_m}`.
+
+  Per BIP-352, a v0 address must carry exactly 66 payload bytes; v1–v30 read the first 66
+  bytes and ignore the rest (forward compatibility); v31 is rejected.
+  """
+  @spec decode_address(String.t()) ::
+          {:ok, {Bitcoinex.Network.network_name(), non_neg_integer(), Point.t(), Point.t()}}
+          | {:error, String.t()}
+  def decode_address(address) when is_binary(address) do
+    with {:ok, {hrp, data}} <- decode_bech32m(address),
+         {:ok, network} <- network_for(hrp),
+         {:ok, {version, payload}} <- parse_sp_data(data),
+         {:ok, {b_scan, b_m}} <- parse_address_keys(payload) do
+      {:ok, {network, version, b_scan, b_m}}
+    end
+  end
+
   # A 32-byte hash is a valid secp256k1 scalar when it is neither 0 nor >= n.
   # Note: PrivateKey.new/1 only rejects d >= n, so this guard is what enforces
   # the non-zero requirement before the callers build a PrivateKey from the hash.
@@ -386,4 +426,57 @@ defmodule Bitcoinex.SilentPayments do
 
   # P - Q = P + (-Q)
   defp subtract(p, q), do: Math.add(p, Point.negate(q))
+
+  defp decode_bech32m(address) do
+    case Bech32.decode(address, :infinity) do
+      {:ok, {:bech32m, hrp, data}} -> {:ok, {hrp, data}}
+      {:ok, {:bech32, _hrp, _data}} -> {:error, "silent payment address must be bech32m"}
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
+  defp parse_sp_data([]), do: {:error, "empty silent payment data"}
+
+  defp parse_sp_data([31 | _rest]), do: {:error, "silent payment version 31 is not supported"}
+
+  defp parse_sp_data([version | rest]) when version in 0..30 do
+    case Bech32.convert_bits(rest, 5, 8, false) do
+      {:ok, bytes} ->
+        payload = :erlang.list_to_binary(bytes)
+
+        cond do
+          version == 0 and byte_size(payload) != 66 ->
+            {:error, "v0 silent payment address must have a 66-byte payload"}
+
+          byte_size(payload) < 66 ->
+            {:error, "silent payment payload too short"}
+
+          true ->
+            {:ok, {version, binary_part(payload, 0, 66)}}
+        end
+
+      {:error, reason} ->
+        {:error, normalize_error(reason)}
+    end
+  end
+
+  defp parse_sp_data(_), do: {:error, "invalid silent payment version"}
+
+  defp parse_address_keys(<<scan::binary-size(33), spend::binary-size(33)>>) do
+    with {:ok, b_scan} <- Point.parse_public_key(scan),
+         {:ok, b_m} <- Point.parse_public_key(spend) do
+      {:ok, {b_scan, b_m}}
+    end
+  end
+
+  defp hrp_for(:mainnet), do: {:ok, "sp"}
+  defp hrp_for(network) when network in [:testnet, :regtest], do: {:ok, "tsp"}
+  defp hrp_for(_), do: {:error, "unsupported network for silent payments"}
+
+  defp network_for("sp"), do: {:ok, :mainnet}
+  defp network_for("tsp"), do: {:ok, :testnet}
+  defp network_for(_), do: {:error, "unrecognized silent payment HRP"}
+
+  defp normalize_error(reason) when is_binary(reason), do: reason
+  defp normalize_error(reason), do: inspect(reason)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bitcoinex.MixProject do
   def project do
     [
       app: :bitcoinex,
-      version: "0.1.8",
+      version: "0.1.9",
       elixir: "~> 1.11",
       package: package(),
       start_permanent: Mix.env() == :prod,

--- a/test/silent_payments_address_test.exs
+++ b/test/silent_payments_address_test.exs
@@ -1,0 +1,121 @@
+defmodule Bitcoinex.SilentPaymentsAddressTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Bitcoinex.{Bech32, SilentPayments}
+  alias Bitcoinex.Secp256k1.{Point, PrivateKey}
+
+  # BIP-352 "Simple send" recipient address and its contained keys.
+  @addr "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+  @scan_pub "0220bcfac5b99e04ad1a06ddfb016ee13582609d60b6291e98d01a9bc9a16c96d4"
+  @spend_pub "025cc9856d6f8375350e123978daac200c260cb5b5ae83106cab90484dcd8fcf36"
+
+  defp point(hex) do
+    {:ok, p} = Point.parse_public_key(Base.decode16!(hex, case: :lower))
+    p
+  end
+
+  defp payload_66, do: Base.decode16!(@scan_pub <> @spend_pub, case: :lower)
+
+  # Encode an SP-style address with an arbitrary version byte and payload (for version rules).
+  defp encode_versioned(version, payload) do
+    {:ok, data} = Bech32.convert_bits(:binary.bin_to_list(payload), 8, 5)
+    {:ok, addr} = Bech32.encode("sp", [version | data], :bech32m, :infinity)
+    addr
+  end
+
+  describe "decode_address/1" do
+    test "decodes a BIP-352 mainnet address into {network, version, B_scan, B_m}" do
+      assert {:ok, {:mainnet, 0, b_scan, b_m}} = SilentPayments.decode_address(@addr)
+      assert Point.serialize_public_key(b_scan) == @scan_pub
+      assert Point.serialize_public_key(b_m) == @spend_pub
+    end
+
+    test "rejects a non-bech32m (bech32) encoding" do
+      assert {:error, _} =
+               SilentPayments.decode_address("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+    end
+
+    test "rejects an unrecognized HRP" do
+      bogus = encode_versioned(0, payload_66()) |> String.replace_prefix("sp1", "zz1")
+      # checksum no longer valid after HRP swap, but either way it must error
+      assert {:error, _} = SilentPayments.decode_address(bogus)
+    end
+
+    test "rejects malformed input" do
+      assert {:error, _} = SilentPayments.decode_address("definitely not an address")
+    end
+  end
+
+  describe "encode_address/3" do
+    test "round-trips the vector address (mainnet)" do
+      {:ok, {_, _, b_scan, b_m}} = SilentPayments.decode_address(@addr)
+      assert SilentPayments.encode_address(b_scan, b_m, :mainnet) == {:ok, @addr}
+    end
+
+    test "uses the sp HRP for mainnet and tsp for testnet/regtest" do
+      b_scan = point(@scan_pub)
+      b_m = point(@spend_pub)
+
+      assert {:ok, "sp1q" <> _} = SilentPayments.encode_address(b_scan, b_m, :mainnet)
+      assert {:ok, "tsp1q" <> _} = SilentPayments.encode_address(b_scan, b_m, :testnet)
+      assert {:ok, "tsp1q" <> _} = SilentPayments.encode_address(b_scan, b_m, :regtest)
+    end
+
+    test "rejects an unsupported network" do
+      assert {:error, _} =
+               SilentPayments.encode_address(point(@scan_pub), point(@spend_pub), :bogus)
+    end
+  end
+
+  describe "version rules" do
+    test "v0 with a non-66-byte payload is rejected" do
+      assert {:error, _} =
+               SilentPayments.decode_address(
+                 encode_versioned(0, binary_part(payload_66(), 0, 65))
+               )
+    end
+
+    test "v1 with a 66-byte payload decodes and reports version 1" do
+      assert {:ok, {:mainnet, 1, b_scan, b_m}} =
+               SilentPayments.decode_address(encode_versioned(1, payload_66()))
+
+      assert Point.serialize_public_key(b_scan) == @scan_pub
+      assert Point.serialize_public_key(b_m) == @spend_pub
+    end
+
+    test "v1-v30 with extra payload bytes reads only the first 66" do
+      padded = payload_66() <> <<0xAB, 0xCD, 0xEF>>
+
+      assert {:ok, {:mainnet, 5, b_scan, b_m}} =
+               SilentPayments.decode_address(encode_versioned(5, padded))
+
+      assert Point.serialize_public_key(b_scan) == @scan_pub
+      assert Point.serialize_public_key(b_m) == @spend_pub
+    end
+
+    test "v31 is rejected" do
+      assert {:error, _} = SilentPayments.decode_address(encode_versioned(31, payload_66()))
+    end
+  end
+
+  property "encode/decode round-trips for any points and network" do
+    check all(
+            scan_d <- StreamData.integer(1..100_000),
+            spend_d <- StreamData.integer(1..100_000),
+            network <- StreamData.member_of([:mainnet, :testnet, :regtest]),
+            max_runs: 40
+          ) do
+      b_scan = PrivateKey.to_point(%PrivateKey{d: scan_d})
+      b_m = PrivateKey.to_point(%PrivateKey{d: spend_d})
+
+      {:ok, addr} = SilentPayments.encode_address(b_scan, b_m, network)
+      {:ok, {net, version, decoded_scan, decoded_m}} = SilentPayments.decode_address(addr)
+
+      assert version == 0
+      assert net == if(network == :mainnet, do: :mainnet, else: :testnet)
+      assert {decoded_scan.x, decoded_scan.y} == {b_scan.x, b_scan.y}
+      assert {decoded_m.x, decoded_m.y} == {b_m.x, b_m.y}
+    end
+  end
+end

--- a/test/silent_payments_address_test.exs
+++ b/test/silent_payments_address_test.exs
@@ -45,6 +45,12 @@ defmodule Bitcoinex.SilentPaymentsAddressTest do
     test "rejects malformed input" do
       assert {:error, _} = SilentPayments.decode_address("definitely not an address")
     end
+
+    test "returns error (does not raise) for a valid-checksum address with a bad SEC prefix" do
+      # 66-byte payload whose B_scan starts with 0x00 (not a valid 0x02/0x03 compressed key).
+      bad_payload = <<0x00>> <> :binary.copy(<<0x07>>, 65)
+      assert {:error, _} = SilentPayments.decode_address(encode_versioned(0, bad_payload))
+    end
   end
 
   describe "encode_address/3" do

--- a/test/silent_payments_vectors_test.exs
+++ b/test/silent_payments_vectors_test.exs
@@ -33,6 +33,8 @@ defmodule Bitcoinex.SilentPaymentsVectorHarness do
                (expected["input_pub_keys"] || []),
              "input_pub_keys mismatch :: #{tcase["comment"]}"
 
+      assert_recipient_addresses(given["recipients"], tcase["comment"])
+
       {taproot, other} =
         Enum.reduce(eligible, {[], []}, fn {r, vin}, {tp, ot} ->
           sk = privkey(vin["private_key"])
@@ -98,6 +100,14 @@ defmodule Bitcoinex.SilentPaymentsVectorHarness do
       b_spend_priv = privkey(given["key_material"]["spend_priv_key"])
       b_spend = PrivateKey.to_point(b_spend_priv)
 
+      assert_receiving_addresses(
+        b_scan,
+        b_spend,
+        given["labels"] || [],
+        expected["addresses"],
+        tcase["comment"]
+      )
+
       {taproot_xonly, other_points} =
         Enum.reduce(vins, {[], []}, fn vin, {tp, ot} ->
           case extract_pubkey(vin) do
@@ -134,6 +144,35 @@ defmodule Bitcoinex.SilentPaymentsVectorHarness do
           verify_found(found, expected["outputs"] || [], b_spend_priv, tcase["comment"])
       end
     end
+  end
+
+  # Sender side: decode each recipient address and check it carries the given keys.
+  defp assert_recipient_addresses(recipients, comment) do
+    for r <- recipients || [] do
+      assert {:ok, {_net, _version, b_scan, b_m}} = SilentPayments.decode_address(r["address"])
+
+      assert Point.serialize_public_key(b_scan) == r["scan_pub_key"],
+             "recipient B_scan mismatch :: #{comment}"
+
+      assert Point.serialize_public_key(b_m) == r["spend_pub_key"],
+             "recipient B_m mismatch :: #{comment}"
+    end
+  end
+
+  # Receiver side: re-encode the base + labeled addresses and compare to the vector.
+  defp assert_receiving_addresses(_b_scan, _b_spend, _labels, nil, _comment), do: :ok
+
+  defp assert_receiving_addresses(b_scan, b_spend, labels, expected_addresses, comment) do
+    {:ok, base} = SilentPayments.encode_address(PrivateKey.to_point(b_scan), b_spend, :mainnet)
+
+    labeled =
+      for m <- labels do
+        {:ok, b_m} = SilentPayments.create_labeled_spend_pubkey(b_spend, b_scan, m)
+        {:ok, addr} = SilentPayments.encode_address(PrivateKey.to_point(b_scan), b_m, :mainnet)
+        addr
+      end
+
+    assert [base | labeled] == expected_addresses, "receiving addresses mismatch :: #{comment}"
   end
 
   # Optional cross-checks against the expected intermediate values, when present.


### PR DESCRIPTION
## Summary

Final PR in the BIP-352 Silent Payments stack. Adds the silent payment **address codec** to `Bitcoinex.SilentPayments`.

- `encode_address/3` — Bech32m of silent-payment version 0 followed by `ser_P(B_scan) || ser_P(B_m)` (66 bytes). HRP `sp` for `:mainnet`, `tsp` for `:testnet`/`:regtest`. Uses an unbounded length cap since SP addresses exceed the 90-char segwit limit.
- `decode_address/1` — returns `{network, version, B_scan, B_m}` and enforces the BIP-352 version rules: v0 must carry exactly 66 payload bytes; v1–v30 read the first 66 and ignore the rest (forward compatibility); v31 is rejected.

## Test plan

- `test/silent_payments_address_test.exs`: decode/encode round-trip on the vector address, HRP selection (`sp`/`tsp`), version rules (v0 length, v1–v30 forward-compat, v31 reject), error cases (non-bech32m, bad HRP, malformed), and a `stream_data` round-trip property over random points and networks.
- The BIP-352 vector harness now also asserts every recipient address decodes to its given `scan_pub_key`/`spend_pub_key` (sending) and that re-encoding the base + labeled addresses matches `expected.addresses` (receiving) — exercising the codec against all vector addresses.
- Bumps version to `0.1.9` and updates `CHANGELOG.md`.
- `mix test` (282 tests + 1 property, 0 failures) and `mix lint.all` pass on Elixir 1.18.1 / OTP 27.

## Stack

S0 negation -> S1 primitives -> S2 send/scan/spend -> **S3 (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
